### PR TITLE
Compatibility fix to run webapp with python3.10

### DIFF
--- a/ictv/common/utils.py
+++ b/ictv/common/utils.py
@@ -19,7 +19,7 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with ICTV.  If not, see <http://www.gnu.org/licenses/>.
 
-import collections
+import collections.abc
 import os
 from datetime import datetime
 import io
@@ -185,7 +185,7 @@ def feedbacks_has_type(type, feedbacks):
 
 def deep_update(d, u):
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             r = deep_update(d.get(k, {}), v)
             d[k] = r
         else:

--- a/ictv/libs/html.py
+++ b/ictv/libs/html.py
@@ -228,7 +228,6 @@ from cgitb import html
 __version__ = '1.16'
 
 import sys
-import cgi
 import unittest
 import html
 
@@ -321,7 +320,6 @@ class HTML(object):
         escape = kw.pop('escape', True)
         if content:
             if escape:
-                #self._content = list(map(cgi.escape, content))
                 self._content = list(map(html.escape, content))
             else:
                 self._content = content
@@ -329,11 +327,9 @@ class HTML(object):
             # special-case to allow control over newlines
             self._newlines = kw.pop('newlines')
         for k in kw:
-            if k == 'klass':                               
-                #self._attrs['class'] = cgi.escape(kw[k], True) # deprecated
+            if k == 'klass':
                 self._attrs['class'] = html.escape(kw[k], True) 
             else:
-                #self._attrs[k] = cgi.escape(kw[k], True) # deprecated
                 self._attrs[k] = html.escape(kw[k], True)
         return self
 

--- a/ictv/libs/html.py
+++ b/ictv/libs/html.py
@@ -224,11 +224,13 @@ See the end of the source file for the license of use.
 XHTML support was contributed by Michael Haubenwallner.
 '''
 from __future__ import with_statement
+from cgitb import html
 __version__ = '1.16'
 
 import sys
 import cgi
 import unittest
+import html
 
 
 class HTML(object):
@@ -293,7 +295,7 @@ class HTML(object):
         special to HTML will be escaped.
         '''
         if escape:
-            text = cgi.escape(text)
+            text = html.escape(text)
         # adding text
         if self._top:
             self._stack[-1]._content.append(text)
@@ -319,17 +321,20 @@ class HTML(object):
         escape = kw.pop('escape', True)
         if content:
             if escape:
-                self._content = list(map(cgi.escape, content))
+                #self._content = list(map(cgi.escape, content))
+                self._content = list(map(html.escape, content))
             else:
                 self._content = content
         if 'newlines' in kw:
             # special-case to allow control over newlines
             self._newlines = kw.pop('newlines')
         for k in kw:
-            if k == 'klass':
-                self._attrs['class'] = cgi.escape(kw[k], True)
+            if k == 'klass':                               
+                #self._attrs['class'] = cgi.escape(kw[k], True) # deprecated
+                self._attrs['class'] = html.escape(kw[k], True) 
             else:
-                self._attrs[k] = cgi.escape(kw[k], True)
+                #self._attrs[k] = cgi.escape(kw[k], True) # deprecated
+                self._attrs[k] = html.escape(kw[k], True)
         return self
 
     def __enter__(self):


### PR DESCRIPTION
We have updated some lines of the code in libs/html.py and common/utils to make ictv work with python3.10. These changes are also compatible with version 3.6 for production.